### PR TITLE
DOC: add documentation of benchmark

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         python -m pip install -r test_requirements.txt
         python -m pytest tests -vv --durations 10 
 
-  update_docs:
+  build_docs:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -74,4 +74,8 @@ jobs:
         python -m pip install --progress-bar=off -r doc_requirements.txt
         make html
         popd
-
+    - name: store docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: docs
+        path: doc_src/build/html

--- a/doc_src/source/benchmarking_asv.rst
+++ b/doc_src/source/benchmarking_asv.rst
@@ -1,0 +1,18 @@
+:orphan:
+
+
+.. _benchmarking_asv:
+
+Benchmarking via ASV
+--------------------
+
+ASV_ is a tool that discovers and runs benchmarks. It saves the state of the
+run and the results, and is useful for comparing performance across versions.
+To run the benchmarks, do:
+
+.. code-block:: shell
+
+    $ cd benchmarks
+    $ asv run
+
+.. _ASV: https://asv.readthedocs.io/en/stable/using.html

--- a/doc_src/source/conf.py
+++ b/doc_src/source/conf.py
@@ -33,6 +33,7 @@ release = 'v0.0.1'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc_src/source/index.rst
+++ b/doc_src/source/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to PNumPy's documentation!
-=============================================
+==================================
 
 .. toctree::
     :maxdepth: 2
@@ -14,11 +14,14 @@ Welcome to PNumPy's documentation!
     installation
     use
 
-Parallel NumPy seamlessly speeds up NumPy for large arrays (64K+ elements) with *no change required to your existing NumPy code*.
+PNumPy seamlessly speeds up NumPy for large arrays (64K+ elements) with *no
+change required to your existing NumPy code*.
 
-This first release speeds up NumPy binary and unary ufuncs such as **add, multiply, isnan, abs, sin, log, sum, min and many more**.
-Sped up functions also include: **sort, argsort, lexsort, boolean indexing, and fancy indexing**.
-In the near future we will speed up: **astype, where, putmask, arange, searchsorted**.
+This first release speeds up NumPy binary and unary ufuncs such as ``add``,
+``multiply``, ``isnan``, ``abs``, ``sin``, ``log``, ``sum``, ``min`` and many more.
+Sped up functions also include: ``sort``, ``argsort``, ``lexsort``, boolean indexing, and
+fancy indexing.  In the near future we will speed up: ``astype``, ``where``, ``putmask``,
+``arange``, ``searchsorted``.
 
 Installation
 ------------
@@ -34,8 +37,10 @@ To use the project:
    import pnumpy as pn
 
 
-Parallel NumPy speeds up NumPy silently under the hood.  To see some benchmarks yourself run
-
+PNumPy speeds up NumPy silently under the hood.  To see some benchmarks
+yourself :ref:`run ASV <benchmarking_asv>` or use the built-in :ref:`benchmark
+<benchmarking>` function:
+ 
 .. code-block:: python
 
    pn.benchmark()
@@ -62,6 +67,9 @@ To cap the number of additional worker threads to 3 run
 
    pn.thread_setworkers(3)
 
+.. _ASV: https://asv.readthedocs.io/en/stable/using.html
+
+
 Additional Functionality
 ------------------------
 
@@ -73,6 +81,7 @@ Threading
 PNumPy uses a combination of threads and 256 bit vector intrinsics to speed up calculations.  By default most operations will only use 3 additional worker threads in combination with the main python thread for a total 4.  Large arrays are divided up into 16K chunks and threads are assigned to maintain cache coherency.  More threads are dynamically deployed for more intensive CPU problems like **np.sin**.  Users can customize threading.  The example below shows how 4 threads can work together to quadruple the effective L2 cache size.
 
 .. image:: ../images/threading_npadd.PNG
+
 
 FAQ
 ---

--- a/doc_src/source/use.rst
+++ b/doc_src/source/use.rst
@@ -1,9 +1,19 @@
 How to use it?
---------------
+==============
 ..
     The rest of this is taken from the __init__.py and the function's docstrings
 
-.. automodule:: pnumpy
-    :members:
+PNumpy functions
+----------------
 
+.. automodule:: pnumpy
+    :members: atop_disable, atop_enable, atop_info, atop_isenabled, atop_setworkers
+
+.. _benchmarking:
+
+Benchmarking
+------------
+
+.. automodule:: pnumpy.benchmark
+    :members:
 

--- a/src/pnumpy/__init__.py
+++ b/src/pnumpy/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
     'thread_enable', 'thread_disable', 'thread_isenabled', 'thread_getworkers', 'thread_setworkers', 'thread_zigzag',
     'ledger_enable', 'ledger_disable', 'ledger_isenabled', 'ledger_info',
     'recycler_enable', 'recycler_disable', 'recycler_isenabled', 'recycler_info',
-    'timer_gettsc','timer_getutc']
+    'timer_gettsc','timer_getutc', 'benchmark']
 
 import numpy as np
 import numpy.core._multiarray_umath as umath

--- a/src/pnumpy/benchmark.py
+++ b/src/pnumpy/benchmark.py
@@ -98,6 +98,7 @@ def benchmark_func(
 
     Examples
     --------
+
     benchmark_func(np.add)
     benchmark_func(np.add, sizes=[2**16])
     benchmark_func(np.sqrt, unary=True)
@@ -127,8 +128,8 @@ def benchmark(
     The output is formatted to be copied and pasted in a csv file.
     A result above 1.0 indicates an improvement, below 1.0 indicates worse peformance.
 
-    Inputs
-    ------
+    Parameters
+    ----------
 
     Returns
     -------


### PR DESCRIPTION
Add benchmarking to documentation. We have two styles: ASV and the internal `benchmark` module.